### PR TITLE
Add username and password to bb-import configuration

### DIFF
--- a/src/lib/Import.js
+++ b/src/lib/Import.js
@@ -12,7 +12,7 @@ class Import {
 	doImport() {
 		this.startTime = process.hrtime();
 		importStart();
-		return packageImport(Config.packageName, {port: Config.port, context: Config.portalContext});
+		return packageImport(Config.packageName, {port: Config.port, context: Config.portalContext, username: Config.portalUsername, password: Config.portalPassword});
 	}
 
 	/**


### PR DESCRIPTION
With this change`portalUsername` and  `portalPassword` can be configured using [bb-watch-cli-configuration](https://github.com/nickthesing/bb-watch-cli-configuration). Should we allow [bb-watch-cli](https://github.com/nickthesing/bb-watch-cli) to accept parameters?